### PR TITLE
docs: add OrcaRouter as a named provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,7 +417,7 @@ uv sync --all-packages
 
 ## Provider & Model Compatibility
 
-Atomic Agents depends on the [Instructor](https://github.com/jxnl/instructor) package. This means that in all examples where OpenAI is used, any other API supported by Instructor can also be used, such as Ollama, Groq, Mistral, Cohere, Anthropic, Gemini, OpenAI and any OpenAI-compatible API such as OpenRouter, MiniMax, EdenAI, and more. For a complete list, please refer to the Instructor documentation on its [GitHub page](https://github.com/jxnl/instructor).
+Atomic Agents depends on the [Instructor](https://github.com/jxnl/instructor) package. This means that in all examples where OpenAI is used, any other API supported by Instructor can also be used, such as Ollama, Groq, Mistral, Cohere, Anthropic, Gemini, OpenAI and any OpenAI-compatible API such as OpenRouter, OrcaRouter, MiniMax, EdenAI, and more. For a complete list, please refer to the Instructor documentation on its [GitHub page](https://github.com/jxnl/instructor).
 
 ## Support
 

--- a/atomic-examples/quickstart/quickstart/4_basic_chatbot_different_providers.py
+++ b/atomic-examples/quickstart/quickstart/4_basic_chatbot_different_providers.py
@@ -90,6 +90,14 @@ def setup_client(provider):
         model = "openai/gpt-4o-mini"
         model_api_parameters = {"max_tokens": 2048}
         assistant_role = "assistant"
+    elif provider == "9" or provider == "orcarouter":
+        from openai import OpenAI as OrcaRouterClient
+
+        api_key = os.getenv("ORCAROUTER_API_KEY")
+        client = instructor.from_openai(OrcaRouterClient(base_url="https://api.orcarouter.ai/v1", api_key=api_key))
+        model = "openai/gpt-5.5"
+        model_api_parameters = {"max_tokens": 2048}
+        assistant_role = "assistant"
     else:
         raise ValueError(f"Unsupported provider: {provider}")
 
@@ -97,7 +105,7 @@ def setup_client(provider):
 
 
 # Prompt the user to choose a provider from one in the list below.
-providers_list = ["openai", "anthropic", "groq", "ollama", "gemini", "openrouter", "minimax", "edenai"]
+providers_list = ["openai", "anthropic", "groq", "ollama", "gemini", "openrouter", "minimax", "edenai", "orcarouter"]
 y = "bold yellow"
 b = "bold blue"
 g = "bold green"

--- a/claude-plugin/atomic-agents/skills/create-atomic-agent/SKILL.md
+++ b/claude-plugin/atomic-agents/skills/create-atomic-agent/SKILL.md
@@ -20,7 +20,7 @@ Bundle into one message:
 
 1. **What should the agent do?** One sentence. Becomes the persona / `background` line.
 2. **Inputs and outputs.** Use `BasicChatInputSchema` / `BasicChatOutputSchema` for free-form chat. Use a custom pair for anything structured (extraction, classification, planning, routing). When custom, branch to the `create-atomic-schema` skill for the schema authoring.
-3. **Provider.** OpenAI / Anthropic / Groq / Ollama / Gemini / OpenRouter / MiniMax. Default: whatever the project already uses; otherwise OpenAI.
+3. **Provider.** OpenAI / Anthropic / Groq / Ollama / Gemini / OpenRouter / OrcaRouter / MiniMax. Default: whatever the project already uses; otherwise OpenAI.
 4. **Conversational?** Yes → wire a `ChatHistory`. No (single-shot transformer) → omit it for stateless behavior.
 5. **Context providers.** Anything to inject into the prompt at runtime (current time, user identity, retrieved docs)? If yes, plan to also use the `create-atomic-context-provider` skill afterwards.
 
@@ -99,7 +99,7 @@ agent = AtomicAgent[MyInput, MyOutput](
             ],
         ),
         # Provider-specific knobs — match the Instructor factory
-        # mode=Mode.TOOLS,                         # OpenAI / Anthropic / OpenRouter
+        # mode=Mode.TOOLS,                         # OpenAI / Anthropic / OpenRouter / OrcaRouter
         # mode=Mode.JSON,                          # Groq / Ollama / MiniMax
         # mode=Mode.GENAI_TOOLS, assistant_role="model",  # Gemini
         model_api_parameters=api_params or {"temperature": 0.2},

--- a/claude-plugin/atomic-agents/skills/framework/references/providers.md
+++ b/claude-plugin/atomic-agents/skills/framework/references/providers.md
@@ -12,6 +12,7 @@ Model IDs in this file are illustrative. Provider model names change often — c
 - Ollama (local)
 - Gemini
 - OpenRouter
+- OrcaRouter
 - MiniMax
 - Picking a model
 - `model_api_parameters` per provider
@@ -27,6 +28,7 @@ Model IDs in this file are illustrative. Provider model names change often — c
 | Ollama | `instructor.from_openai(OpenAI(base_url=..., api_key="ollama"), mode=Mode.JSON)` | `Mode.JSON` | `"assistant"` | OpenAI-compatible |
 | Gemini | `instructor.from_genai(google.genai.Client(...), mode=Mode.GENAI_TOOLS)` | `Mode.GENAI_TOOLS` | `"model"` | Native |
 | OpenRouter | `instructor.from_openai(OpenAI(base_url=..., api_key=...))` | `Mode.TOOLS` | `"assistant"` | OpenAI-compatible |
+| OrcaRouter | `instructor.from_openai(OpenAI(base_url=..., api_key=...))` | `Mode.TOOLS` | `"assistant"` | OpenAI-compatible |
 | MiniMax | `instructor.from_openai(OpenAI(base_url=..., api_key=...), mode=Mode.JSON)` | `Mode.JSON` | `"assistant"` | OpenAI-compatible |
 
 The `mode` value is passed to `AgentConfig(mode=...)` **and** sometimes to the Instructor factory itself. Match them.
@@ -123,6 +125,22 @@ api_params = {"max_tokens": 2048}
 ```
 
 OpenRouter is a gateway to many providers via OpenAI-compatible protocol. Model ids use `provider/model` form.
+
+## OrcaRouter
+
+```python
+import os, instructor
+from openai import OpenAI
+
+client = instructor.from_openai(OpenAI(
+    base_url="https://api.orcarouter.ai/v1",
+    api_key=os.environ["ORCAROUTER_API_KEY"],
+))
+model = "openai/gpt-5.5"   # OrcaRouter's namespaced model id syntax
+api_params = {"max_tokens": 2048}
+```
+
+OrcaRouter is an OpenAI-compatible routing gateway that exposes models from OpenAI, Anthropic, Google, DeepSeek, Qwen and others behind a single endpoint and API key. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes. Model ids use the `provider/model` form.
 
 ## MiniMax
 

--- a/claude-plugin/atomic-agents/skills/new-app/SKILL.md
+++ b/claude-plugin/atomic-agents/skills/new-app/SKILL.md
@@ -16,7 +16,7 @@ This skill is opinionated. Produce a complete, tested skeleton the user can run 
 Ask these questions in one message, not one-at-a-time. Skip any the user already answered (including via `$ARGUMENTS`).
 
 1. **Project name** — used as both directory name and package name. Default from `$ARGUMENTS` if provided. Normalize to `kebab-case` for the directory and `snake_case` for the package.
-2. **LLM provider** — OpenAI / Anthropic / Groq / Ollama / Gemini / OpenRouter / MiniMax. Default: OpenAI.
+2. **LLM provider** — OpenAI / Anthropic / Groq / Ollama / Gemini / OpenRouter / OrcaRouter / MiniMax. Default: OpenAI.
 3. **Agent type** — a rough one-liner. Shapes the default `SystemPromptGenerator` content and the starter schema pair. Defaults to a generic chat agent.
 4. **Tooling** — `uv` (default, because the repo uses uv) or `pip + venv`.
 
@@ -92,6 +92,7 @@ Per-provider AgentConfig knobs — match the Instructor factory mode on `AgentCo
 - **Groq / Ollama / MiniMax**: `mode=Mode.JSON` (Instructor factory also uses `Mode.JSON`).
 - **Gemini**: `assistant_role="model"` and `mode=Mode.GENAI_TOOLS` (Instructor factory uses `Mode.GENAI_TOOLS`).
 - **OpenRouter**: `mode=Mode.TOOLS`.
+- **OrcaRouter**: `mode=Mode.TOOLS`.
 
 ### `README.md`
 
@@ -131,7 +132,7 @@ https://eigenwise.github.io/atomic-agents/llms.txt
 - Test: `uv run pytest`
 ```
 
-Provider-specific lines for the template: Anthropic → "Requires `max_tokens` in `model_api_parameters`; `mode=Mode.TOOLS`." Gemini → "`assistant_role='model'` and `mode=Mode.GENAI_TOOLS`." Groq/Ollama/MiniMax → "`mode=Mode.JSON` on both the Instructor factory and `AgentConfig`." OpenAI/OpenRouter → omit.
+Provider-specific lines for the template: Anthropic → "Requires `max_tokens` in `model_api_parameters`; `mode=Mode.TOOLS`." Gemini → "`assistant_role='model'` and `mode=Mode.GENAI_TOOLS`." Groq/Ollama/MiniMax → "`mode=Mode.JSON` on both the Instructor factory and `AgentConfig`." OpenAI/OpenRouter/OrcaRouter → omit.
 
 ## Phase 4 — Install and smoke-test
 

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -289,7 +289,8 @@ The framework supports multiple AI providers:
     "groq": "mixtral-8x7b-32768",
     "ollama": "llama3",
     "gemini": "gemini-2.0-flash-exp",
-    "openrouter": "mistral/ministral-8b"
+    "openrouter": "mistral/ministral-8b",
+    "orcarouter": "openai/gpt-5.5"
 }
 ```
 
@@ -373,13 +374,24 @@ def setup_client(provider):
         )
         model = "mistral/ministral-8b"
 
+    elif provider == "orcarouter":
+        from openai import OpenAI as OrcaRouterClient
+        api_key = os.getenv("ORCAROUTER_API_KEY")
+        client = instructor.from_openai(
+            OrcaRouterClient(
+                base_url="https://api.orcarouter.ai/v1",
+                api_key=api_key
+            )
+        )
+        model = "openai/gpt-5.5"
+
     else:
         raise ValueError(f"Unsupported provider: {provider}")
 
     return client, model
 
 # Prompt for provider choice
-provider = console.input("Choose a provider (openai/anthropic/groq/ollama/gemini/openrouter): ").lower()
+provider = console.input("Choose a provider (openai/anthropic/groq/ollama/gemini/openrouter/orcarouter): ").lower()
 
 # Set up client and model
 client, model = setup_client(provider)


### PR DESCRIPTION
## Summary

Adds [OrcaRouter](https://www.orcarouter.ai) as a named provider alongside the existing OpenRouter entry. OrcaRouter is an OpenAI-compatible model routing gateway that exposes models from OpenAI, Anthropic, Google, DeepSeek, Qwen and others behind a single endpoint and API key. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

I'm an engineer on the OrcaRouter team.

## What this changes

- `README.md`: lists OrcaRouter in the supported-provider list.
- `docs/guides/quickstart.md`: adds the `orcarouter` entry to the provider map, the `setup_client` branch, and the provider-choice prompt.
- `atomic-examples/quickstart/quickstart/4_basic_chatbot_different_providers.py`: adds the `orcarouter` branch (base URL `https://api.orcarouter.ai/v1`, auth via `ORCAROUTER_API_KEY`, model `openai/gpt-5.5`) and the provider prompt entry.
- `claude-plugin/atomic-agents/skills/framework/references/providers.md`: adds an OrcaRouter row to the provider matrix and a dedicated section mirroring the OpenRouter wiring.
- `claude-plugin/atomic-agents/skills/new-app/SKILL.md`: mentions OrcaRouter in the provider lists.
- `claude-plugin/atomic-agents/skills/create-atomic-agent/SKILL.md`: mentions OrcaRouter in the provider lists.

## Why a separate provider rather than the OpenAI-compatible escape hatch

This mirrors how OpenRouter is wired in this repo, so the provider prompt, docs and example stay consistent for users who pick OrcaRouter.

## How to use it

1. Get an API key at https://www.orcarouter.ai/console (keys start with `sk-orca-`).
2. Set `ORCAROUTER_API_KEY`.
3. Run the quickstart example and pick `orcarouter`, or build a client directly:

```python
import os, instructor
from openai import OpenAI as OrcaRouterClient

client = instructor.from_openai(
    OrcaRouterClient(base_url="https://api.orcarouter.ai/v1", api_key=os.getenv("ORCAROUTER_API_KEY"))
)
model = "openai/gpt-5.5"
```

The model id is namespaced (`openai/gpt-5.5`, `anthropic/claude-sonnet-4.6`, ...), which the router uses to route to the matching upstream.

## Verification

- The quickstart example file passes `python -m py_compile`.
- Live connectivity against `https://api.orcarouter.ai/v1` with an `sk-orca-` key:
  - `instructor.from_openai(OpenAI(base_url=..., api_key=...))` with `model="openai/gpt-5.5"` → 200, structured output against a Pydantic schema.
