### PR TITLE
Fix FAQ upgrade guide link

### DIFF
--- a/docs/guides/faq.md
+++ b/docs/guides/faq.md
@@ -565,4 +565,4 @@ agent = AtomicAgent[MyInput, MyOutput](
 )
 ```
 
-See the [Upgrade Guide](../UPGRADE_DOC.md) for complete migration instructions.
+See the [Upgrade Guide](../../UPGRADE_DOC.md) for complete migration instructions.


### PR DESCRIPTION
## Summary

- Fix the FAQ Upgrade Guide link so it resolves from `docs/guides/` to the repository-root `UPGRADE_DOC.md`.

## Validation

- Verified that the corrected target exists.
- Ran `git diff --check`.
