### PR TITLE
Fix Atomic Forge license links

### DIFF
--- a/atomic-forge/tools/calculator/README.md
+++ b/atomic-forge/tools/calculator/README.md
@@ -56,4 +56,4 @@ Please ensure you follow the project's coding standards and include tests for an
 
 ## License
 
-This project is licensed under the same license as the main Atomic Agents project. See the [LICENSE](LICENSE) file in the repository root for more details.
+This project is licensed under the same license as the main Atomic Agents project. See the [LICENSE](../../../LICENSE) file in the repository root for more details.

--- a/atomic-forge/tools/webpage_scraper/README.md
+++ b/atomic-forge/tools/webpage_scraper/README.md
@@ -86,4 +86,4 @@ Please ensure you follow the project's coding standards and include tests for an
 
 ## License
 
-This project is licensed under the same license as the main Atomic Agents project. See the [LICENSE](LICENSE) file in the repository root for more details.
+This project is licensed under the same license as the main Atomic Agents project. See the [LICENSE](../../../LICENSE) file in the repository root for more details.

--- a/atomic-forge/tools/youtube_transcript_scraper/README.md
+++ b/atomic-forge/tools/youtube_transcript_scraper/README.md
@@ -99,4 +99,4 @@ Please ensure you follow the project's coding standards and include tests for an
 
 ## License
 
-This project is licensed under the same license as the main Atomic Agents project. See the [LICENSE](LICENSE) file in the repository root for more details.
+This project is licensed under the same license as the main Atomic Agents project. See the [LICENSE](../../../LICENSE) file in the repository root for more details.


### PR DESCRIPTION
## Summary

- Fix the license links in three Atomic Forge tool READMEs so they resolve to the repository-root `LICENSE` file.

## Validation

- Verified that all corrected relative paths resolve to `LICENSE`.
- Ran `git diff --check`.
