### PR TITLE
fix(mcp): include resource templates alongside resources

### DIFF
--- a/atomic-agents/atomic_agents/connectors/mcp/mcp_definition_service.py
+++ b/atomic-agents/atomic_agents/connectors/mcp/mcp_definition_service.py
@@ -11,6 +11,7 @@ from mcp import ClientSession, StdioServerParameters
 from mcp.client.sse import sse_client
 from mcp.client.stdio import stdio_client
 from mcp.client.streamable_http import streamablehttp_client
+from mcp.shared.exceptions import McpError
 import mcp.types as types
 from pydantic import AnyUrl
 from urllib.parse import unquote as decode_uri
@@ -251,10 +252,14 @@ class MCPDefinitionService:
 
             resources_iterable: List[types.Resource] = list(response.resources or [])
 
-            if not resources_iterable:
+            try:
                 res_templates: types.ListResourceTemplatesResult = await session.list_resource_templates()
+            except McpError as error:
+                if error.error.code != types.METHOD_NOT_FOUND:
+                    raise
+            else:
                 for template in res_templates.resourceTemplates:
-                    # Resources have no "input_schema" value and use URI templates with parameters.
+                    # Resource templates have no "input_schema" value and use URI templates with parameters.
                     resources_iterable.append(
                         types.Resource(
                             name=template.name,

--- a/atomic-agents/tests/connectors/mcp/test_mcp_definition_service.py
+++ b/atomic-agents/tests/connectors/mcp/test_mcp_definition_service.py
@@ -1,6 +1,9 @@
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import mcp.types as types
+from mcp.shared.exceptions import McpError
+
 from atomic_agents.connectors.mcp import (
     MCPDefinitionService,
     MCPToolDefinition,
@@ -57,6 +60,7 @@ def mock_client_session():
     mock_response.resources = [mock_resource]
     mock_response.uri = "resource://TestResource/{id}"
     mock_session.list_resources.return_value = mock_response
+    mock_session.list_resource_templates.return_value = types.ListResourceTemplatesResult(resourceTemplates=[])
 
     mock_prompt = MagicMock()
     mock_prompt.name = "welcome"
@@ -326,6 +330,57 @@ class TestToolDefinitionService:
         mock_client_session.list_resources.assert_called_once()
 
     @pytest.mark.asyncio
+    async def test_fetch_resource_definitions_from_session_includes_templates_with_static_resources(self):
+        mock_session = AsyncMock()
+        mock_session.list_resources.return_value = types.ListResourcesResult(
+            resources=[types.Resource(name="current_config", uri="config://current")]
+        )
+        mock_session.list_resource_templates.return_value = types.ListResourceTemplatesResult(
+            resourceTemplates=[types.ResourceTemplate(name="user_profile", uriTemplate="users://{user_id}")]
+        )
+
+        result = await MCPDefinitionService.fetch_resource_definitions_from_session(mock_session)
+
+        assert [definition.name for definition in result] == ["current_config", "user_profile"]
+        assert result[1].uri == "users://{user_id}"
+        assert result[1].input_schema == {
+            "type": "object",
+            "properties": {"user_id": {"type": "string", "description": "URI parameter user_id"}},
+            "required": ["user_id"],
+        }
+        mock_session.list_resources.assert_awaited_once()
+        mock_session.list_resource_templates.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_fetch_resource_definitions_from_session_allows_unsupported_templates(self):
+        mock_session = AsyncMock()
+        mock_session.list_resources.return_value = types.ListResourcesResult(
+            resources=[types.Resource(name="current_config", uri="config://current")]
+        )
+        mock_session.list_resource_templates.side_effect = McpError(
+            types.ErrorData(code=types.METHOD_NOT_FOUND, message="Method not found")
+        )
+
+        result = await MCPDefinitionService.fetch_resource_definitions_from_session(mock_session)
+
+        assert [definition.name for definition in result] == ["current_config"]
+        mock_session.list_resource_templates.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_fetch_resource_definitions_from_session_propagates_template_errors(self):
+        mock_session = AsyncMock()
+        mock_session.list_resources.return_value = types.ListResourcesResult(
+            resources=[types.Resource(name="current_config", uri="config://current")]
+        )
+        template_error = McpError(types.ErrorData(code=types.INTERNAL_ERROR, message="Template listing failed"))
+        mock_session.list_resource_templates.side_effect = template_error
+
+        with pytest.raises(McpError) as exc_info:
+            await MCPDefinitionService.fetch_resource_definitions_from_session(mock_session)
+
+        assert exc_info.value is template_error
+
+    @pytest.mark.asyncio
     async def test_fetch_prompt_definitions_from_session(self, mock_client_session):
         result = await MCPDefinitionService.fetch_prompt_definitions_from_session(mock_client_session)
 
@@ -490,6 +545,7 @@ async def test_fetch_resources_from_session_no_resources(caplog):
     sess = AsyncMock()
     sess.initialize = AsyncMock()
     sess.list_resources = AsyncMock(return_value=_NoResourcesResponse())
+    sess.list_resource_templates = AsyncMock(return_value=types.ListResourceTemplatesResult(resourceTemplates=[]))
 
     result = await MCPDefinitionService.fetch_resource_definitions_from_session(sess)
     assert result == []
@@ -524,6 +580,7 @@ async def test_fetch_resources_from_session(caplog):
     mock_response.resources = [mock_resource]
 
     sess.list_resources = AsyncMock(return_value=mock_response)
+    sess.list_resource_templates = AsyncMock(return_value=types.ListResourceTemplatesResult(resourceTemplates=[]))
 
     result = await MCPDefinitionService.fetch_resource_definitions_from_session(sess)
 


### PR DESCRIPTION
## Summary

- discover MCP resource templates even when a server also returns static resources
- preserve static-resource discovery when a server does not implement `resources/templates/list`
- add regression coverage for mixed discovery and MCP error handling

## Why

`resources/list` and `resources/templates/list` are separate discovery endpoints. The current fallback-only call skips all templates whenever `resources/list` is non-empty.

The compatibility path ignores only JSON-RPC `-32601 Method not found`; every other MCP error still propagates.

## Testing

- `uv run black --check atomic-agents atomic-assembler atomic-examples atomic-forge`
- `uv run flake8 --extend-exclude=.venv atomic-agents atomic-assembler atomic-examples atomic-forge`
- `uv run pytest --cov=atomic_agents atomic-agents` — 339 passed, 3 skipped